### PR TITLE
Fix errors when building crosshatch

### DIFF
--- a/compatibility_matrices/compatibility_matrix.3.xml
+++ b/compatibility_matrices/compatibility_matrix.3.xml
@@ -472,4 +472,12 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <hal format="hidl" optional="true">
+        <name>vendor.google.wifi_ext</name>
+        <version>1.1</version>
+        <interface>
+            <name>IWifiExt</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
 </compatibility-matrix>


### PR DESCRIPTION
error:
files are incompatible: The following instances are in the device manifest but not specified in framework compatibility matrix: vendor.google.wifi_ext@1.1::IWifiExt/default,RuntimeError: VINTF compatibility check failed.