### PR TITLE
Fix sub-HAL handle in dynamic sensor meta events

### DIFF
--- a/sensors/common/default/2.X/multihal/HalProxyCallback.cpp
+++ b/sensors/common/default/2.X/multihal/HalProxyCallback.cpp
@@ -68,6 +68,10 @@ std::vector<V2_1::Event> HalProxyCallbackBase::processEvents(const std::vector<V
     std::vector<V2_1::Event> eventsOut;
     for (V2_1::Event event : events) {
         event.sensorHandle = setSubHalIndex(event.sensorHandle, mSubHalIndex);
+        if (event.sensorType == V2_1::SensorType::DYNAMIC_SENSOR_META) {
+            event.u.dynamic.sensorHandle =
+                    setSubHalIndex(event.u.dynamic.sensorHandle, mSubHalIndex);
+        }
         eventsOut.push_back(event);
         const V2_1::SensorInfo& sensor = mCallback->getSensorInfo(event.sensorHandle);
         if ((sensor.flags & V1_0::SensorFlagBits::WAKE_UP) != 0) {


### PR DESCRIPTION
Need to apply the sub-HAL index byte to ensure handles provided in
DYNAMIC_SENSOR_META events align properly with the [dis]connected
callbacks.

Bug: 228879057
Test: try on device with dynamic sensors sub-HAL at index > 0
Change-Id: Ic7290b51733bb829a5494ef41e9430b51dc6074e