### PR TITLE
camera: Update HIDL overrideFormat from HAL

### DIFF
--- a/camera/device/3.2/default/CameraDeviceSession.cpp
+++ b/camera/device/3.2/default/CameraDeviceSession.cpp
@@ -926,12 +926,12 @@ bool CameraDeviceSession::preProcessConfigurationLocked(
                     mStreamMap[id].data_space);
             mCirculatingBuffers.emplace(stream.mId, CirculatingBuffers{});
         } else {
-            // width/height/format must not change, but usage/rotation might need to change
+            // width/height must not change, but usage/rotation might need to change
+            // format might change and get updated with overrideFormat
             if (mStreamMap[id].stream_type !=
                     (int) requestedConfiguration.streams[i].streamType ||
                     mStreamMap[id].width != requestedConfiguration.streams[i].width ||
                     mStreamMap[id].height != requestedConfiguration.streams[i].height ||
-                    mStreamMap[id].format != (int) requestedConfiguration.streams[i].format ||
                     mStreamMap[id].data_space !=
                             mapToLegacyDataspace( static_cast<android_dataspace_t> (
                                     requestedConfiguration.streams[i].dataSpace))) {

--- a/camera/device/3.2/default/convert.cpp
+++ b/camera/device/3.2/default/convert.cpp
@@ -66,6 +66,8 @@ void convertFromHidl(const Stream &src, Camera3Stream* dst) {
     dst->data_space = (android_dataspace_t) src.dataSpace;
     dst->rotation = (int) src.rotation;
     dst->usage = (uint32_t) src.usage;
+    dst->reserved[0] = NULL;
+    dst->reserved[1] = NULL;
     // Fields to be filled by HAL (max_buffers, priv) are initialized to 0
     dst->max_buffers = 0;
     dst->priv = 0;
@@ -87,6 +89,23 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
         // bi-directional stream to HIDL.
         ALOGW("%s: Stream type %d is not currently supported!",
                 __FUNCTION__, src->stream_type);
+    }
+
+    HalStream* halStream = NULL;
+    if (src->reserved[0] != NULL) {
+        halStream = (HalStream*)(src->reserved[0]);
+    } else if (src->reserved[1] != NULL) {
+        halStream = (HalStream*)(src->reserved[1]);
+    }
+
+    // Check if overrideFormat is set and honor it
+    if (halStream != NULL) {
+        dst->overrideFormat = (PixelFormat) halStream->overrideFormat;
+        if (src->stream_type == CAMERA3_STREAM_OUTPUT) {
+            dst->producerUsage = (BufferUsageFlags)halStream->producerUsage;
+        } else if (src->stream_type == CAMERA3_STREAM_INPUT) {
+            dst->consumerUsage = (BufferUsageFlags)halStream->consumerUsage;
+        }
     }
 }
 

--- a/camera/device/3.3/default/convert.cpp
+++ b/camera/device/3.3/default/convert.cpp
@@ -47,6 +47,22 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
         ALOGW("%s: Stream type %d is not currently supported!",
                 __FUNCTION__, src->stream_type);
     }
+
+    HalStream* halStream = NULL;
+    if (src->reserved[0] != NULL) {
+        halStream = (HalStream*)(src->reserved[0]);
+    } else if (src->reserved[1] != NULL) {
+        halStream = (HalStream*)(src->reserved[1]);
+    }
+
+    if (halStream != NULL) {
+        dst->v3_2.overrideFormat  = (PixelFormat) halStream->v3_2.overrideFormat;
+        if (src->stream_type == CAMERA3_STREAM_OUTPUT) {
+            dst->v3_2.producerUsage = (BufferUsageFlags)halStream->v3_2.producerUsage;
+        } else if (src->stream_type == CAMERA3_STREAM_INPUT) {
+            dst->v3_2.consumerUsage = (BufferUsageFlags)halStream->v3_2.consumerUsage;
+        }
+    }
 }
 
 void convertToHidl(const camera3_stream_configuration_t& src, HalStreamConfiguration* dst) {


### PR DESCRIPTION
--HAL requires 64 bit usage flags to support more feature --Re-used one of the reserved locations to read 64bit usage flags and override format

This is needed for some camera ports such as MIUI camera.

CRs-fixed: 2264577
Change-Id: I9a4cbb80b1c2d82ec4af3941f0d98b67ecfd59ef
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>
Signed-off-by: DennySPb <dennyspb@gmail.com>