### PR TITLE
frameworks: Update HIDL overrideFormat from HAL

### DIFF
--- a/camera/device/3.2/default/Android.bp
+++ b/camera/device/3.2/default/Android.bp
@@ -9,7 +9,10 @@ package {
 
 cc_library_shared {
     name: "camera.device@3.2-impl",
-    defaults: ["hidl_defaults"],
+    defaults: [
+        "hidl_defaults", 
+        "camera_uses_newer_hidl_override_format_defaults",
+    ],
     proprietary: true,
     srcs: [
         "CameraDevice.cpp",

--- a/camera/device/3.2/default/CameraDeviceSession.cpp
+++ b/camera/device/3.2/default/CameraDeviceSession.cpp
@@ -926,12 +926,12 @@ bool CameraDeviceSession::preProcessConfigurationLocked(
                     mStreamMap[id].data_space);
             mCirculatingBuffers.emplace(stream.mId, CirculatingBuffers{});
         } else {
-            // width/height/format must not change, but usage/rotation might need to change
+            // width/height must not change, but usage/rotation might need to change
+            // format might change and get updated with overrideFormat
             if (mStreamMap[id].stream_type !=
                     (int) requestedConfiguration.streams[i].streamType ||
                     mStreamMap[id].width != requestedConfiguration.streams[i].width ||
                     mStreamMap[id].height != requestedConfiguration.streams[i].height ||
-                    mStreamMap[id].format != (int) requestedConfiguration.streams[i].format ||
                     mStreamMap[id].data_space !=
                             mapToLegacyDataspace( static_cast<android_dataspace_t> (
                                     requestedConfiguration.streams[i].dataSpace))) {

--- a/camera/device/3.2/default/CameraDeviceSession.cpp
+++ b/camera/device/3.2/default/CameraDeviceSession.cpp
@@ -927,11 +927,14 @@ bool CameraDeviceSession::preProcessConfigurationLocked(
             mCirculatingBuffers.emplace(stream.mId, CirculatingBuffers{});
         } else {
             // width/height must not change, but usage/rotation might need to change
-            // format might change and get updated with overrideFormat
+            // format might change and get updated with overrideFormat if TARGET_CAMERA_USES_NEWER_HIDL_OVERRIDE_FORMAT = true
             if (mStreamMap[id].stream_type !=
                     (int) requestedConfiguration.streams[i].streamType ||
                     mStreamMap[id].width != requestedConfiguration.streams[i].width ||
                     mStreamMap[id].height != requestedConfiguration.streams[i].height ||
+#ifndef TARGET_CAMERA_USES_NEWER_HIDL_OVERRIDE_FORMAT
+                    mStreamMap[id].format != (int) requestedConfiguration.streams[i].format ||
+#endif
                     mStreamMap[id].data_space !=
                             mapToLegacyDataspace( static_cast<android_dataspace_t> (
                                     requestedConfiguration.streams[i].dataSpace))) {

--- a/camera/device/3.2/default/convert.cpp
+++ b/camera/device/3.2/default/convert.cpp
@@ -74,6 +74,8 @@ void convertFromHidl(const Stream &src, Camera3Stream* dst) {
     dst->data_space = (android_dataspace_t) src.dataSpace;
     dst->rotation = (int) src.rotation;
     dst->usage = (uint32_t) src.usage;
+    dst->reserved[0] = NULL;
+    dst->reserved[1] = NULL;
     // Fields to be filled by HAL (max_buffers, priv) are initialized to 0
     dst->max_buffers = 0;
     dst->priv = 0;
@@ -95,6 +97,23 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
         // bi-directional stream to HIDL.
         ALOGW("%s: Stream type %d is not currently supported!",
                 __FUNCTION__, src->stream_type);
+    }
+
+    HalStream* halStream = NULL;
+    if (src->reserved[0] != NULL) {
+        halStream = (HalStream*)(src->reserved[0]);
+    } else if (src->reserved[1] != NULL) {
+        halStream = (HalStream*)(src->reserved[1]);
+    }
+
+    // Check if overrideFormat is set and honor it
+    if (halStream != NULL) {
+        dst->overrideFormat = (PixelFormat) halStream->overrideFormat;
+        if (src->stream_type == CAMERA3_STREAM_OUTPUT) {
+            dst->producerUsage = (BufferUsageFlags)halStream->producerUsage;
+        } else if (src->stream_type == CAMERA3_STREAM_INPUT) {
+            dst->consumerUsage = (BufferUsageFlags)halStream->consumerUsage;
+        }
     }
 }
 

--- a/camera/device/3.2/default/convert.cpp
+++ b/camera/device/3.2/default/convert.cpp
@@ -74,8 +74,10 @@ void convertFromHidl(const Stream &src, Camera3Stream* dst) {
     dst->data_space = (android_dataspace_t) src.dataSpace;
     dst->rotation = (int) src.rotation;
     dst->usage = (uint32_t) src.usage;
+#ifdef TARGET_CAMERA_USES_NEWER_HIDL_OVERRIDE_FORMAT
     dst->reserved[0] = NULL;
     dst->reserved[1] = NULL;
+#endif
     // Fields to be filled by HAL (max_buffers, priv) are initialized to 0
     dst->max_buffers = 0;
     dst->priv = 0;
@@ -99,6 +101,7 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
                 __FUNCTION__, src->stream_type);
     }
 
+#ifdef TARGET_CAMERA_USES_NEWER_HIDL_OVERRIDE_FORMAT
     HalStream* halStream = NULL;
     if (src->reserved[0] != NULL) {
         halStream = (HalStream*)(src->reserved[0]);
@@ -115,6 +118,7 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
             dst->consumerUsage = (BufferUsageFlags)halStream->consumerUsage;
         }
     }
+#endif
 }
 
 void convertToHidl(const camera3_stream_configuration_t& src, HalStreamConfiguration* dst) {

--- a/camera/device/3.3/default/Android.bp
+++ b/camera/device/3.3/default/Android.bp
@@ -9,7 +9,10 @@ package {
 
 cc_library_shared {
     name: "camera.device@3.3-impl",
-    defaults: ["hidl_defaults"],
+    defaults: [
+        "hidl_defaults", 
+        "camera_uses_newer_hidl_override_format_defaults",
+    ],
     proprietary: true,
     srcs: [
         "CameraDevice.cpp",

--- a/camera/device/3.3/default/convert.cpp
+++ b/camera/device/3.3/default/convert.cpp
@@ -47,6 +47,22 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
         ALOGW("%s: Stream type %d is not currently supported!",
                 __FUNCTION__, src->stream_type);
     }
+
+    HalStream* halStream = NULL;
+    if (src->reserved[0] != NULL) {
+        halStream = (HalStream*)(src->reserved[0]);
+    } else if (src->reserved[1] != NULL) {
+        halStream = (HalStream*)(src->reserved[1]);
+    }
+
+    if (halStream != NULL) {
+        dst->v3_2.overrideFormat  = (PixelFormat) halStream->v3_2.overrideFormat;
+        if (src->stream_type == CAMERA3_STREAM_OUTPUT) {
+            dst->v3_2.producerUsage = (BufferUsageFlags)halStream->v3_2.producerUsage;
+        } else if (src->stream_type == CAMERA3_STREAM_INPUT) {
+            dst->v3_2.consumerUsage = (BufferUsageFlags)halStream->v3_2.consumerUsage;
+        }
+    }
 }
 
 void convertToHidl(const camera3_stream_configuration_t& src, HalStreamConfiguration* dst) {

--- a/camera/device/3.3/default/convert.cpp
+++ b/camera/device/3.3/default/convert.cpp
@@ -48,6 +48,7 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
                 __FUNCTION__, src->stream_type);
     }
 
+#ifdef TARGET_CAMERA_USES_NEWER_HIDL_OVERRIDE_FORMAT
     HalStream* halStream = NULL;
     if (src->reserved[0] != NULL) {
         halStream = (HalStream*)(src->reserved[0]);
@@ -63,6 +64,7 @@ void convertToHidl(const Camera3Stream* src, HalStream* dst) {
             dst->v3_2.consumerUsage = (BufferUsageFlags)halStream->v3_2.consumerUsage;
         }
     }
+#endif
 }
 
 void convertToHidl(const camera3_stream_configuration_t& src, HalStreamConfiguration* dst) {


### PR DESCRIPTION
--HAL requires 64 bit usage flags to support more feature --Re-used one of the reserved locations to read 64bit usage flags and override format

CRs-fixed: 2264577
Change-Id: I9a4cbb80b1c2d82ec4af3941f0d98b67ecfd59ef