### PR TITLE
compatibility_matrices: Add p/android-4.4 into FCM 4

### DIFF
--- a/compatibility_matrices/Android.bp
+++ b/compatibility_matrices/Android.bp
@@ -28,6 +28,7 @@ vintf_compatibility_matrix {
         "compatibility_matrix.4.xml",
     ],
     kernel_configs: [
+        "kernel_config_p_4.4",
         "kernel_config_q_4.9",
         "kernel_config_q_4.14",
         "kernel_config_q_4.19",


### PR DESCRIPTION
Xiaomi Mix 2 (chiron) uses kernel 4.4, so we need this patch so that 4.4 is considered good for A14.

The patch was taken from https://review.lineageos.org/q/topic:%2214-android-4.4%22 the rest of the changes are already implemented on current repos, so we need just this:

FCM 3 is gone, so just add it there.

Change-Id: I34b163281e9b110c9efb6d9f2cd63ac986265abf